### PR TITLE
Fix lyrics offset on macOS Big Sur and later

### DIFF
--- a/LyricsX/Base.lproj/Main.storyboard
+++ b/LyricsX/Base.lproj/Main.storyboard
@@ -258,6 +258,7 @@
                     <connections>
                         <outlet property="lyricsOffsetStepper" destination="FwA-Sj-odc" id="Wpt-Xo-ryF"/>
                         <outlet property="lyricsOffsetTextField" destination="BE8-Ux-QD2" id="U25-Zx-LxS"/>
+                        <outlet property="lyricsOffsetView" destination="LV9-pp-2tz" id="XY6-hn-HAX"/>
                         <outlet property="statusBarMenu" destination="OCV-Y8-x1C" id="zHx-WQ-Hu4"/>
                     </connections>
                 </customObject>
@@ -451,7 +452,7 @@
                     <constraints>
                         <constraint firstItem="DG2-8b-vTy" firstAttribute="centerY" secondItem="LV9-pp-2tz" secondAttribute="centerY" id="5gA-e2-0RM"/>
                         <constraint firstItem="BE8-Ux-QD2" firstAttribute="leading" secondItem="DG2-8b-vTy" secondAttribute="trailing" constant="8" id="66I-Ch-hG0"/>
-                        <constraint firstItem="DG2-8b-vTy" firstAttribute="leading" secondItem="LV9-pp-2tz" secondAttribute="leading" constant="21" id="826-cy-w1T"/>
+                        <constraint firstItem="DG2-8b-vTy" firstAttribute="leading" secondItem="LV9-pp-2tz" secondAttribute="leading" constant="21" identifier="lyricsOffsetConstraint" id="826-cy-w1T"/>
                         <constraint firstItem="FwA-Sj-odc" firstAttribute="leading" secondItem="BE8-Ux-QD2" secondAttribute="trailing" constant="5" id="9G1-eA-c8X"/>
                         <constraint firstItem="BE8-Ux-QD2" firstAttribute="top" secondItem="LV9-pp-2tz" secondAttribute="top" constant="2" id="Jw4-sr-Qu8"/>
                         <constraint firstItem="0ii-PC-ZCl" firstAttribute="centerY" secondItem="LV9-pp-2tz" secondAttribute="centerY" id="Yhp-74-yJR"/>

--- a/LyricsX/Component/AppDelegate.swift
+++ b/LyricsX/Component/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         return NSApplication.shared.delegate as? AppDelegate
     }
     
+    @IBOutlet weak var lyricsOffsetView: NSView!
     @IBOutlet weak var lyricsOffsetTextField: NSTextField!
     @IBOutlet weak var lyricsOffsetStepper: NSStepper!
     @IBOutlet weak var statusBarMenu: NSMenu!
@@ -138,6 +139,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
     
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.item(withTag: 202)?.isEnabled = AppController.shared.currentLyrics != nil
+    }
+    
+    func menuWillOpen(_ menu: NSMenu) {
+        if #available(macOS 10.16, *) {
+            let menuHasOnState = statusBarMenu.items.filter { menuItem in
+                return menuItem.state == .on
+            }.count > 0
+
+            let lyricsOffsetConstraint = lyricsOffsetView.constraints.first(where: {$0.identifier == "lyricsOffsetConstraint"})
+            
+            lyricsOffsetConstraint?.constant = 14
+            if menuHasOnState {
+                lyricsOffsetConstraint?.constant += 10
+            }
+        }
     }
     
     // MARK: - Menubar Action


### PR DESCRIPTION
This pull request fixes the alignment of the lyrics offset view on macOS Big Sur and later.

Before:
<img width="288" alt="Before off" src="https://user-images.githubusercontent.com/2276355/187262849-0de1c47b-0b1f-468c-9ad9-1476bbc94391.png"> <img width="288" alt="Before on" src="https://user-images.githubusercontent.com/2276355/187262850-8bf97a5a-5d03-4fc7-8d9a-89afdc0d6c7f.png">

After:
<img width="291" alt="After off" src="https://user-images.githubusercontent.com/2276355/187262844-5bd2c367-57a6-4a23-bbf3-820d3c5ece0a.png"> <img width="288" alt="After on" src="https://user-images.githubusercontent.com/2276355/187262848-b327ffcd-c200-40a7-a40a-12958dcfa6da.png">